### PR TITLE
Fix/streamline focus behavior

### DIFF
--- a/quake-terminal@diegodario88.github.io/quake-mode.js
+++ b/quake-terminal@diegodario88.github.io/quake-mode.js
@@ -177,7 +177,6 @@ export const QuakeMode = class {
 				}
 
 				this._setupHideFromOverviewAndAltTab();
-				this.terminalWindow.make_above();
 
 				this._terminalWindowUnmanagedId = this.terminalWindow.connect(
 					"unmanaged",

--- a/quake-terminal@diegodario88.github.io/quake-mode.js
+++ b/quake-terminal@diegodario88.github.io/quake-mode.js
@@ -141,7 +141,7 @@ export const QuakeMode = class {
 			return;
 		}
 
-		if (this.terminalWindow.has_focus() || !this.terminalWindow.minimized) {
+		if (this.terminalWindow.has_focus() && !this.terminalWindow.minimized) {
 			return this._hideTerminalWithAnimationBottomUp();
 		}
 


### PR DESCRIPTION
Streamlines the hiding/stay on top/focus behavior of the extension.

- fix a bug that requires to press the trigger-key twice to regain a usable terminal when focus is lost
- streamline always-on-top behavior by removing it, since it is not necessary

Tested on Gnome Shell 45.0, Arch Linux, X11 and Wayland, 4-Monitor setup.