### PR TITLE
Remove chance for race condition

### DIFF
--- a/quake-terminal@diegodario88.github.io/quake-mode.js
+++ b/quake-terminal@diegodario88.github.io/quake-mode.js
@@ -172,7 +172,6 @@ export const QuakeMode = class {
 			return Promise.reject(new Error("No Terminal APP"));
 		}
 
-		this._terminal.open_new_window(-1);
 
 		return new Promise((resolve, reject) => {
 			const shellAppWindowsChangedHandler = () => {
@@ -219,6 +218,8 @@ export const QuakeMode = class {
 					return GLib.SOURCE_REMOVE;
 				}
 			);
+
+			this._terminal.open_new_window(-1);
 		});
 	}
 


### PR DESCRIPTION
Currently, the request for opening a new terminal window is issued before the app-windows-changed signal handler is set up. Depending on backend implementation, system state, or pure chance, there is a chance of missing the event and thus, getting the extension stuck in an unrecoverable state.

Requesting a new window after the handler is set up does prevent missing the event.

Does not seem to cause an issue in single-terminal mode, however, as I pushed the project towards one terminal per workspace, erratic behavior started to show up - and I tracked it down to this.