### PR TITLE
Allow interrupting the sliding animation

### DIFF
--- a/quake-terminal@diegodario88.github.io/quake-mode.js
+++ b/quake-terminal@diegodario88.github.io/quake-mode.js
@@ -17,7 +17,6 @@ export const QuakeMode = class {
 	constructor(terminal, settings) {
 		this._terminal = terminal;
 		this._settings = settings;
-		this._isTransitioning = false;
 		this._internalState = TERMINAL_STATE.READY;
 		this._sourceTimeoutLoopId = null;
 		this._terminalWindowUnmanagedId = null;
@@ -119,7 +118,6 @@ export const QuakeMode = class {
 		this._connectedSignals = [];
 		this._settingsWatchingListIds = [];
 		this._terminal = null;
-		this._isTransitioning = false;
 		this._internalState = TERMINAL_STATE.DEAD;
 	}
 
@@ -279,10 +277,6 @@ export const QuakeMode = class {
 			return true;
 		}
 
-		if (this._isTransitioning) {
-			return true;
-		}
-
 		if (!this.actor) {
 			return true;
 		}
@@ -301,7 +295,6 @@ export const QuakeMode = class {
 			return;
 		}
 
-		this._isTransitioning = true;
 		parent.set_child_above_sibling(this.actor, null);
 		this.actor.translation_y = this.actor.height * -1;
 
@@ -311,10 +304,7 @@ export const QuakeMode = class {
 		this.actor.ease({
 			mode: Clutter.AnimationMode.EASE_IN_QUAD,
 			translation_y: 0,
-			duration: ANIMATION_TIME_IN_MILLISECONDS,
-			onComplete: () => {
-				this._isTransitioning = false;
-			},
+			duration: ANIMATION_TIME_IN_MILLISECONDS
 		});
 
 		this._fitTerminalToMainMonitor();
@@ -325,8 +315,6 @@ export const QuakeMode = class {
 			return;
 		}
 
-		this.isTransition = true;
-
 		this.actor.ease({
 			mode: Clutter.AnimationMode.EASE_OUT_QUAD,
 			translation_y: this.actor.height * -1,
@@ -335,7 +323,6 @@ export const QuakeMode = class {
 				Main.wm.skipNextEffect(this.actor);
 				this.actor.meta_window.minimize();
 				this.actor.translation_y = 0;
-				this._isTransitioning = false;
 			},
 		});
 	}


### PR DESCRIPTION
Up until now, one has to wait for the sliding animation to complete before the hotkey has an affect again.

With a configured long animation time, that forces users to wait for some time to correct for example an accidental hit of the hotkey.

Removing the counters speeds up usage, ups felt performance and reduces code complexity.

Might actually complement https://github.com/diegodario88/quake-terminal/pull/13 as in:
- Let peope configure having pleasing animations
- but in casehaving pressed the hotkey by mistake, allow them to cancel said animation and move on with their work.

