### PR TITLE
feat: display monitor description instead of model 

### DIFF
--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -204,7 +204,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 
 		for (const [idx, monitor] of monitorScreens.entries()) {
 			const monitorScreen = new GenericObjectModel(
-				`${monitor.model}`.toUpperCase(),
+				`${monitor.description}`.toUpperCase(),
 				idx
 			);
 			monitorScreenModel.append(monitorScreen);


### PR DESCRIPTION
Display monitor 'description' instead of 'model' in order to align with Gnome Display Settings.

Current version displaying monitor model:
![Screenshot from 2023-11-05 16-14-50](https://github.com/diegodario88/quake-terminal/assets/676869/bc7a3de2-259f-4032-9efd-c0b1a9bd3d03)


Proposed version displaying monitor description:
![Screenshot from 2023-11-05 16-18-17](https://github.com/diegodario88/quake-terminal/assets/676869/cb6197ee-0787-4a6d-89f1-cd18946f223b)

