### PR TITLE
feat: update Quake Terminal preferences

### DIFF
--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -222,7 +222,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 
 		// Shortcut
 		const shortcutId = "terminal-shortcut";
-		const rowShortcut = new Adw.ActionRow({
+		const shortcutRow = new Adw.ActionRow({
 			title: _("Toggle Shortcut"),
 			subtitle: _("Shortcut to activate the terminal application"),
 		});
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 			shortcutLabel.set_accelerator(settings.get_strv(shortcutId)[0]);
 		});
 
-		rowShortcut.connect("activated", () => {
+		shortcutRow.connect("activated", () => {
 			const ctl = new Gtk.EventControllerKey();
 
 			const statusPage = new Adw.StatusPage({
@@ -269,6 +269,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 			});
 
 			editor.add_controller(ctl);
+
 			ctl.connect("key-pressed", (_, keyval, keycode, state) => {
 				let mask = state & Gtk.accelerator_get_default_mod_mask();
 				mask &= ~Gdk.ModifierType.LOCK_MASK;
@@ -296,9 +297,9 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 			editor.present();
 		});
 
-		rowShortcut.add_suffix(shortcutLabel);
-		rowShortcut.activatable_widget = shortcutLabel;
-		generalSettingsGroup.add(rowShortcut);
+		shortcutRow.add_suffix(shortcutLabel);
+		shortcutRow.activatable_widget = shortcutLabel;
+		generalSettingsGroup.add(shortcutRow);
 
 		// Auto Hide Window
 		const autoHideWindowRow = new Adw.SwitchRow({

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -8,6 +8,18 @@ import {
 	gettext as _,
 } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
+const ABOUT_TERMINAL_APPLICATION_HELP_DIALOG = `
+<markup>
+  <span font_desc='11'>When this row is activated, the system searches for installed apps based on specific criteria that each app must meet:</span>
+
+  <span font_desc='10'> - A valid <a href="https://developer.gnome.org/documentation/tutorials/application-id.html">Application ID</a>.</span>
+  <span font_desc='10'> - Should not be hidden.</span>
+  <span font_desc='10'> - Must have <i>terminal</i> specified in its categories metadata.</span>
+
+  <small>This process ensures accurate and relevant results. For help and more information, refer to <a href="https://github.com/diegodario88/quake-terminal">Quake Terminal</a>.</small>
+</markup>
+`;
+
 /**
  *
  * @returns GdkMonitor[]

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -37,6 +37,15 @@ const isValidAccel = (mask, keyval) => {
 	);
 };
 
+function getAppIconImage(app) {
+	const appIconString = app.get_icon()?.to_string() ?? "icon-missing";
+
+	return new Gtk.Image({
+		gicon: Gio.icon_new_for_string(appIconString),
+		iconSize: Gtk.IconSize.LARGE,
+	});
+}
+
 const GenericObjectModel = GObject.registerClass(
 	{
 		Properties: {

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -74,6 +74,57 @@ const GenericObjectModel = GObject.registerClass(
 	}
 );
 
+/** Dialog window used for selecting application from given list of apps
+ *  Emits `app-selected` signal with application id
+ */
+const AppChooserDialog = GObject.registerClass(
+	{
+		Properties: {},
+		Signals: { "app-selected": { param_types: [GObject.TYPE_STRING] } },
+	},
+	class AppChooserDialog extends Adw.PreferencesWindow {
+		/**
+		 * @param apps list of apps to display in dialog
+		 * @param parent parent window, dialog will be transient for parent
+		 */
+		_init(apps, parent) {
+			super._init({
+				modal: true,
+				transientFor: parent,
+				destroyWithParent: false,
+				title: "Select terminal application",
+			});
+
+			this.set_default_size(
+				0.7 * parent.defaultWidth,
+				0.7 * parent.defaultHeight
+			);
+			this._group = new Adw.PreferencesGroup();
+			const page = new Adw.PreferencesPage();
+			page.add(this._group);
+			this.add(page);
+			apps.forEach((app) => this._addAppRow(app));
+		}
+
+		/** for given app add row to selectable list */
+		_addAppRow(app) {
+			const row = new Adw.ActionRow({
+				title: app.get_display_name(),
+				subtitle: app.get_description(),
+				activatable: true,
+			});
+
+			row.add_prefix(getAppIconImage(app));
+			this._group.add(row);
+
+			row.connect("activated", () => {
+				this.emit("app-selected", app.get_id());
+				this.close();
+			});
+		}
+	}
+);
+
 export default class QuakeTerminalPreferences extends ExtensionPreferences {
 	fillPreferencesWindow(window) {
 		const settings = this.getSettings();

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -17,7 +17,7 @@ const getConnectedMonitorsList = () => {
 
 	const display = Gdk.Display.get_default(); // Gets the default GdkDisplay
 	if (display && "get_monitors" in display) {
-		const monitorsAvailable = display.get_monitors();  // Gets the list of monitors associated with this display.
+		const monitorsAvailable = display.get_monitors(); // Gets the list of monitors associated with this display.
 
 		for (let idx = 0; idx < monitorsAvailable.get_n_items(); idx++) {
 			const monitor = monitorsAvailable.get_item(idx);
@@ -82,7 +82,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 		// App ID
 		const rowId = new Adw.ActionRow({
 			title: _("Terminal App ID"),
-			subtitle: "/usr/share/applications/",
+			subtitle: _("Client application identifier"),
 		});
 		generalSettingsGroup.add(rowId);
 
@@ -93,6 +93,50 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 			hexpand: true,
 		});
 
+		const helpButton = Gtk.Button.new_from_icon_name("help-about-symbolic", {
+			valign: Gtk.Align.CENTER,
+		});
+		helpButton.add_css_class("flat");
+
+		helpButton.connect("clicked", () => {
+			const helpDialogLabel = new Gtk.Label({
+				margin_top: 12,
+				margin_start: 24,
+				margin_end: 24,
+				margin_bottom: 24,
+				wrap: true,
+				label: _(
+					"Some useful information about how to setup. \n\n Aspects of how to find include: \n\n • something directory \n • something path \n • something other stuff"
+				),
+			});
+
+			const helpDialogScrolledWindow = new Gtk.ScrolledWindow({
+				propagate_natural_height: true,
+				vscrollbar_policy: Gtk.PolicyType.NEVER,
+			});
+			helpDialogScrolledWindow.set_child(helpDialogLabel);
+
+			const helpButtonToolbarView = new Adw.ToolbarView({
+				content: helpDialogScrolledWindow,
+			});
+
+			helpButtonToolbarView.add_top_bar(new Adw.HeaderBar());
+
+			const helpDialog = new Adw.Window({
+				title: "About Terminal App ID",
+				modal: true,
+				transient_for: page.get_root(),
+				hide_on_close: true,
+				width_request: 360,
+				height_request: 200,
+				default_width: 420,
+				resizable: false,
+				content: helpButtonToolbarView,
+			});
+
+			helpDialog.present();
+		});
+
 		settings.bind(
 			"terminal-id",
 			entryId,
@@ -101,6 +145,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 		);
 
 		rowId.add_suffix(entryId);
+		rowId.add_suffix(helpButton);
 		rowId.activatable_widget = entryId;
 
 		// Shortcut
@@ -251,7 +296,9 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 			model: monitorScreenModel,
 			expression: new Gtk.PropertyExpression(GenericObjectModel, null, "name"),
 			selected: settings.get_int("monitor-screen"),
-			sensitive: !settings.get_boolean("render-on-current-monitor") && !settings.get_boolean("render-on-primary-monitor"),
+			sensitive:
+				!settings.get_boolean("render-on-current-monitor") &&
+				!settings.get_boolean("render-on-primary-monitor"),
 		});
 
 		generalSettingsGroup.add(monitorRow);
@@ -263,21 +310,31 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 		// watch for render-on-current-monitor changes
 		settings.connect("changed::render-on-current-monitor", () => {
 			// set render-on-primary-monitor to false when render-on-current-monitor was set to true
-			if (settings.get_boolean("render-on-current-monitor") && settings.get_boolean("render-on-primary-monitor")) {
+			if (
+				settings.get_boolean("render-on-current-monitor") &&
+				settings.get_boolean("render-on-primary-monitor")
+			) {
 				settings.set_boolean("render-on-primary-monitor", false);
 			}
 			// disable selecting a monitor screen
-			monitorRow.set_sensitive(!settings.get_boolean("render-on-current-monitor"));
+			monitorRow.set_sensitive(
+				!settings.get_boolean("render-on-current-monitor")
+			);
 		});
 
 		// watch for render-on-primary-monitor changes
 		settings.connect("changed::render-on-primary-monitor", () => {
 			// set render-on-current-monitor to false when render-on-primary-monitor was set to true
-			if (settings.get_boolean("render-on-primary-monitor") && settings.get_boolean("render-on-current-monitor")) {
+			if (
+				settings.get_boolean("render-on-primary-monitor") &&
+				settings.get_boolean("render-on-current-monitor")
+			) {
 				settings.set_boolean("render-on-current-monitor", false);
 			}
 			// disable selecting a monitor screen
-			monitorRow.set_sensitive(!settings.get_boolean("render-on-primary-monitor"));
+			monitorRow.set_sensitive(
+				!settings.get_boolean("render-on-primary-monitor")
+			);
 		});
 
 		// Animation Time

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -152,9 +152,21 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 		page.add(applicationSettingsGroup);
 
 		// Application Terminal ID
-		const selectedTerminalEmulator = Gio.DesktopAppInfo.new(
-			settings.get_string("terminal-id")
+		const terminalApplicationId = settings.get_string("terminal-id");
+
+		let selectedTerminalEmulator = Gio.DesktopAppInfo.new(
+			terminalApplicationId
 		);
+
+		if (!selectedTerminalEmulator) {
+			console.warn(
+				`Unable to locate a terminal application with the specified ID (${terminalApplicationId}). Falling back to the default terminal.`
+			);
+
+			selectedTerminalEmulator = Gio.DesktopAppInfo.new(
+				settings.get_default_value("terminal-id").deep_unpack()
+			);
+		}
 
 		const applicationIDRow = new Adw.ActionRow({
 			title: _("Terminal Application"),

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -164,9 +164,8 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 		applicationSettingsGroup.add(applicationIDRow);
 		applicationIDRow.set_subtitle(selectedTerminalEmulator.get_id());
 
-		const helpButton = Gtk.Button.new_from_icon_name("help-about-symbolic", {
-			valign: Gtk.Align.CENTER,
-		});
+		const helpButton = Gtk.Button.new_from_icon_name("help-about-symbolic");
+		helpButton.set_valign(Gtk.Align.CENTER);
 		helpButton.add_css_class("flat");
 
 		helpButton.connect("clicked", () => {


### PR DESCRIPTION
- Added functionality to select the terminal application in the preferences.
- Users can now choose their preferred terminal emulator from a list of available options.
- The selected terminal application ID is stored in the settings.
- The selected terminal application ID is displayed in the preferences UI.
- Added an icon and help button to provide information about the selected terminal application.
- Updated the help dialog to include relevant information about setting up the terminal application.

This commit adds the ability for users to customize their terminal experience by selecting their preferred terminal application.