### PR TITLE
fix: check if categories are null when filtering applications

### DIFF
--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,12 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories()?.toLowerCase().includes("terminal");
+					const appCategories = app.get_categories();
+					if (!appCategories) {
+						return false;
+					}
+
+					return appCategories.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories().toLowerCase().includes("terminal");
+					return app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories()?.toLowerCase().includes("terminal");
+					return app.should_show() && app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.should_show() && app.get_categories()?.toLowerCase().includes("terminal");
+					return app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 


### PR DESCRIPTION
fix for #22 


seems like a documentation error because `get_categories()` can return `null`, but the docs mention only string: https://gjs-docs.gnome.org/gio20~2.0/gio.desktopappinfo#method-get_categories