### PR TITLE
Do not try to get an app icon and an ID for org.gnome.Terminal.desktop when it's not available

### DIFF
--- a/quake-terminal@diegodario88.github.io/extension.js
+++ b/quake-terminal@diegodario88.github.io/extension.js
@@ -63,6 +63,12 @@ export default class TogglerExtension extends Extension {
 			this._quakeMode._internalState === TERMINAL_STATE.DEAD
 		) {
 			const terminalId = this._settings.get_string("terminal-id");
+
+			if (!terminalId) {
+				Main.notify(_(`Select an application in Quake Terminal preferences.`));
+				return;
+			}
+
 			const terminal = this._appSystem.lookup_app(terminalId);
 
 			if (!terminal) {

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,12 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories()?.toLowerCase().includes("terminal");
+					const appCategories = app.get_categories();
+					if (!appCategories) {
+						return false;
+					}
+
+					return appCategories.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories().toLowerCase().includes("terminal");
+					return app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -50,7 +50,7 @@ const isValidAccel = (mask, keyval) => {
 };
 
 function getAppIconImage(app) {
-	const appIconString = app.get_icon()?.to_string() ?? "icon-missing";
+	const appIconString = app?.get_icon()?.to_string() ?? "icon-missing";
 
 	return new Gtk.Image({
 		gicon: Gio.icon_new_for_string(appIconString),
@@ -163,9 +163,14 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 				`Unable to locate a terminal application with the specified ID (${terminalApplicationId}). Falling back to the default terminal.`
 			);
 
+			const defaultTerminalApplicationId = settings.get_default_value("terminal-id").deep_unpack();
 			selectedTerminalEmulator = Gio.DesktopAppInfo.new(
-				settings.get_default_value("terminal-id").deep_unpack()
+				defaultTerminalApplicationId
 			);
+
+			if (!selectedTerminalEmulator) {
+				console.warn(`Unable to locate default terminal application (${defaultTerminalApplicationId}).`);
+			}
 		}
 
 		const applicationIDRow = new Adw.ActionRow({
@@ -174,7 +179,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 
 		const gtkIcon = getAppIconImage(selectedTerminalEmulator);
 		applicationSettingsGroup.add(applicationIDRow);
-		applicationIDRow.set_subtitle(selectedTerminalEmulator.get_id());
+		applicationIDRow.set_subtitle(selectedTerminalEmulator?.get_id() ?? 'Gnome Terminal not found. Click here to select another terminal app.');
 
 		const helpButton = Gtk.Button.new_from_icon_name("help-about-symbolic");
 		helpButton.set_valign(Gtk.Align.CENTER);

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.get_categories()?.toLowerCase().includes("terminal");
+					return app.should_show() && app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 

--- a/quake-terminal@diegodario88.github.io/prefs.js
+++ b/quake-terminal@diegodario88.github.io/prefs.js
@@ -238,7 +238,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
 						return false;
 					}
 
-					return app.should_show() && app.get_categories()?.toLowerCase().includes("terminal");
+					return app.get_categories()?.toLowerCase().includes("terminal");
 				})
 				.sort((a, b) => a.get_id().localeCompare(b.get_id()));
 


### PR DESCRIPTION
It seems that without org.gnome.Terminal.desktop installed, the preferences window is not opening.
With this PR I tried to account for this use case.

This is how the preferences will look like:
![image](https://github.com/diegodario88/quake-terminal/assets/676869/78a9b9c7-9644-42ac-8706-434214c97906)

Fixes #24. 