### PR TITLE
Fix for Gnome 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -3,7 +3,7 @@
   "version": 17,
   "name": "Quake Terminal",
   "description": "Quickly launch a terminal in Quake mode using a keyboard shortcut",
-  "shell-version": ["45", "46", "47", "48"],
+  "shell-version": ["45", "46", "47", "48", "49"],
   "settings-schema": "org.gnome.shell.extensions.quake-terminal",
   "url": "https://github.com/diegodario88/quake-terminal",
   "version-name": "1.6.7",


### PR DESCRIPTION
Update metadata.json

GNOME 49 support, tested on Arch-Linux