### PR TITLE
Ignore wl-clipboard windows to prevent focus stealing

### DIFF
--- a/src/quake-mode.js
+++ b/src/quake-mode.js
@@ -709,21 +709,11 @@ export const QuakeMode = class {
   _handleAlwaysOnTop() {
     const shouldAlwaysOnTop = this._settings.get_boolean("always-on-top");
 
-    if (!shouldAlwaysOnTop) {
+    if (!shouldAlwaysOnTop && !this.terminalWindow.is_above()) {
       return;
     }
 
-    const focusedWindow = Shell.Global.get().display.focus_window;
-
-    if (focusedWindow && is_wlclipboard(focusedWindow)) {
-      return;
-    }
-
-    if (!this.terminalWindow.is_above()) {
-      return;
-    }
-
-    if (this.terminalWindow.is_above()) {
+    if (!shouldAlwaysOnTop && this.terminalWindow.is_above()) {
       this.terminalWindow.unmake_above();
       return;
     }


### PR DESCRIPTION
`wl-copy` / `wl-paste` use a hack to gain access to the system clipboard. This hack requires creating a window for a fraction of a second, which causes the terminal window to lose focus unnecessarily and incorrectly triggers the auto-hide function.

Filter `wl-clipboard` windows to fix the issue.