### PR TITLE
Improve support for GNOME 49

### DIFF
--- a/src/metadata.json
+++ b/src/metadata.json
@@ -1,6 +1,6 @@
 {
   "uuid": "quake-terminal@diegodario88.github.io",
-  "version": 17,
+  "version": 27,
   "name": "Quake Terminal",
   "description": "Quickly launch a terminal in Quake mode using a keyboard shortcut",
   "shell-version": ["45", "46", "47", "48", "49"],

--- a/src/prefs.js
+++ b/src/prefs.js
@@ -9,6 +9,11 @@ import {
   gettext as _,
 } from "resource:///org/gnome/Shell/Extensions/js/extensions/prefs.js";
 
+// Use GioUnix on GNOME 49+, but fallback to plain Gio for older versions
+const GioUnix = await import("gi://GioUnix")
+  .then((module) => module.default)
+  .catch(() => Gio);
+
 const ABOUT_TERMINAL_APPLICATION_HELP_DIALOG = `
 <markup>
   <span font_desc='11'>When this row is activated, the system searches for installed apps based on specific criteria that each app must meet:</span>
@@ -181,7 +186,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
       title: _("Terminal Application"),
     });
 
-    let selectedTerminalEmulator = Gio.DesktopAppInfo.new(
+    let selectedTerminalEmulator = GioUnix.DesktopAppInfo.new(
       terminalApplicationId
     );
 
@@ -190,7 +195,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
         `Unable to locate a terminal application with the specified ID (${terminalApplicationId}). Falling back to the default terminal (${defaultTerminalApplicationId}).`
       );
 
-      selectedTerminalEmulator = Gio.DesktopAppInfo.new(
+      selectedTerminalEmulator = GioUnix.DesktopAppInfo.new(
         defaultTerminalApplicationId
       );
     }
@@ -318,7 +323,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
       appChooserDialog.connect("app-selected", (_source, appId) => {
         settings.set_string("terminal-id", appId);
 
-        const newSelectedTerminalEmulator = Gio.DesktopAppInfo.new(appId);
+        const newSelectedTerminalEmulator = GioUnix.DesktopAppInfo.new(appId);
         applicationIDRow.set_subtitle(newSelectedTerminalEmulator.get_id());
 
         const appIconString =


### PR DESCRIPTION
GNOME 49 has moved `DesktopAppInfo` to the new `GioUnix` module ([glib!4761](https://gitlab.gnome.org/GNOME/glib/-/merge_requests/4761 "girepository: Remove backward compatibility introspection from Gio-2.0")). Which causes the following warning to show up in logs:

```log
Gio.DesktopAppInfo has been moved to a separate platform-specific library. Please update your code to use GioUnix.DesktopAppInfo instead.
0 get() ["resource:///org/gnome/gjs/modules/core/overrides/Gio.js":510:46]
1 fillPreferencesWindow() ["file:///home/marmis/.local/share/gnome-shell/extensions/quake-terminal@diegodario88.github.io/prefs.js":184:36]
2 _loadPrefs() ["resource:///org/gnome/Shell/Extensions/js/extensionPrefsDialog.js":43:24]
3 AsyncFunctionNext() ["self-hosted":800:27]
4 _init/GLib.MainLoop.prototype.runAsync/</<() ["resource:///org/gnome/gjs/modules/core/overrides/GLib.js":263:34]
```

To avoid this log and any breakage in the future, I'm proposing already moving to `GioUnix`, with fallback to `Gio` in older versions.

## Screenshots

GNOME 49:

<img width="600" alt="Screenshot From 2025-09-08 07-10-13" src="https://github.com/user-attachments/assets/445544d3-8e92-4042-af82-8541a1e403ec" />

<img width="600" alt="Screenshot From 2025-09-08 07-10-18" src="https://github.com/user-attachments/assets/d526d9c9-4b14-4be4-a843-6e8691649b5c" />

> [!NOTE]
> **NOT TESTED ON GNOME 45...48 YET**, BUT IT SHOULD WORK.