### PR TITLE
Reduce Vertical Size lower limit to 10 percent

### DIFF
--- a/src/prefs.js
+++ b/src/prefs.js
@@ -576,7 +576,7 @@ export default class QuakeTerminalPreferences extends ExtensionPreferences {
       title: _("Vertical Size"),
       subtitle: _("Terminal vertical distance as a percentage"),
       adjustment: new Gtk.Adjustment({
-        lower: 30,
+        lower: 10,
         step_increment: 5,
         upper: 100,
         value: settings.get_int("vertical-size"),


### PR DESCRIPTION
Currently the vertical size can't be set to less than 30%
Please either remove this limit or lower it to 10-20%

When you have your displays arranged in portrait mode (I.e. rotated 90 degrees), a terminal taking 10-20% of the display size vertically, is quite usable.

https://github.com/diegodario88/quake-terminal/issues/66