### PR TITLE
feat: add support for GNOME 50

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,11 +1,11 @@
 {
-  "name": "Quake Terminal",
+  "name": "quake-terminal",
   "version": "1.0.5",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
-      "name": "Quake Terminal",
+      "name": "quake-terminal",
       "version": "1.0.5",
       "license": "LGPL-3.0-or-later",
       "devDependencies": {

--- a/src/metadata.json
+++ b/src/metadata.json
@@ -8,7 +8,8 @@
     "46",
     "47",
     "48",
-    "49"
+    "49",
+    "50"
   ],
   "settings-schema": "org.gnome.shell.extensions.quake-terminal",
   "url": "https://github.com/diegodario88/quake-terminal",

--- a/src/quake-mode.js
+++ b/src/quake-mode.js
@@ -3,7 +3,10 @@ import GLib from "gi://GLib";
 import Gio from "gi://Gio";
 import Shell from "gi://Shell";
 import Meta from "gi://Meta";
+import { PACKAGE_VERSION } from "resource:///org/gnome/shell/misc/config.js";
 import * as Main from "resource:///org/gnome/shell/ui/main.js";
+
+const SHELL_VERSION = Number.parseInt(PACKAGE_VERSION.split(".")[0]);
 
 const STARTUP_TIMER_IN_SECONDS = 5;
 
@@ -32,7 +35,7 @@ export const QuakeMode = class {
    */
   constructor(terminal, settings) {
     console.log(
-      `*** QuakeTerminal@constructor - IsWayland = ${Meta.is_wayland_compositor()} ***`
+      `*** QuakeTerminal@constructor - IsWayland = ${SHELL_VERSION >= 50 || Meta.is_wayland_compositor()} ***`
     );
     console.log(
       `*** QuakeTerminal@constructor - Terminal App = ${terminal.get_name()} ***`


### PR DESCRIPTION
GNOME is now Wayland-only and have no `is_wayland_compositor()` anymore. See [mutter!4505](https://gitlab.gnome.org/GNOME/mutter/-/merge_requests/4505/diffs?commit_id=b4348951ec9f0ea8d043c7bb9536a90c8d3904cf "Drop is_wayland_compositor checks").

Tested on GNOME 50.beta and 50.rc. GNOME 50.0 is [scheduled for release on 2026/03/14](https://release.gnome.org/calendar/ "GNOME Release Calendar").